### PR TITLE
Adicionando Informações de Mais Anos

### DIFF
--- a/docs/site/dados/inicial/agua-branca-inicial.json
+++ b/docs/site/dados/inicial/agua-branca-inicial.json
@@ -2,8 +2,8 @@
   "id": "agua-branca",
   "nome": "ÁGUA BRANCA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 59,
+    "2020": {
+      "num_diarios": 9,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 46,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 59,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 26,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 105,
+    "num_diarios": 140,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/anadia-inicial.json
+++ b/docs/site/dados/inicial/anadia-inicial.json
@@ -2,19 +2,29 @@
   "id": "anadia",
   "nome": "ANADIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 164,
-      "num_nomeacoes": 10,
-      "num_exoneracoes": 3
+    "2020": {
+      "num_diarios": 16,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 130,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 164,
+      "num_nomeacoes": 10,
+      "num_exoneracoes": 3
+    },
+    "2023": {
+      "num_diarios": 46,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 294,
+    "num_diarios": 356,
     "num_exoneracoes": 3,
     "num_nomeacoes": 10
   }

--- a/docs/site/dados/inicial/arapiraca-inicial.json
+++ b/docs/site/dados/inicial/arapiraca-inicial.json
@@ -2,20 +2,40 @@
   "id": "arapiraca",
   "nome": "ARAPIRACA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 232,
-      "num_nomeacoes": 118,
-      "num_exoneracoes": 10
+    "2016": {
+      "num_diarios": 183,
+      "num_nomeacoes": 6,
+      "num_exoneracoes": 1
+    },
+    "2017": {
+      "num_diarios": 174,
+      "num_nomeacoes": 4,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 219,
+      "num_nomeacoes": 69,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 221,
       "num_nomeacoes": 36,
       "num_exoneracoes": 1
+    },
+    "2022": {
+      "num_diarios": 232,
+      "num_nomeacoes": 118,
+      "num_exoneracoes": 10
+    },
+    "2023": {
+      "num_diarios": 65,
+      "num_nomeacoes": 55,
+      "num_exoneracoes": 12
     }
   },
   "resumo": {
-    "num_diarios": 453,
-    "num_exoneracoes": 11,
-    "num_nomeacoes": 154
+    "num_diarios": 1094,
+    "num_exoneracoes": 24,
+    "num_nomeacoes": 288
   }
 }

--- a/docs/site/dados/inicial/atalaia-inicial.json
+++ b/docs/site/dados/inicial/atalaia-inicial.json
@@ -2,20 +2,35 @@
   "id": "atalaia",
   "nome": "ATALAIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 164,
-      "num_nomeacoes": 45,
-      "num_exoneracoes": 6
+    "2017": {
+      "num_diarios": 13,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 150,
+      "num_nomeacoes": 82,
+      "num_exoneracoes": 10
     },
     "2021": {
       "num_diarios": 126,
       "num_nomeacoes": 31,
       "num_exoneracoes": 6
+    },
+    "2022": {
+      "num_diarios": 164,
+      "num_nomeacoes": 45,
+      "num_exoneracoes": 6
+    },
+    "2023": {
+      "num_diarios": 49,
+      "num_nomeacoes": 32,
+      "num_exoneracoes": 3
     }
   },
   "resumo": {
-    "num_diarios": 290,
-    "num_exoneracoes": 12,
-    "num_nomeacoes": 76
+    "num_diarios": 502,
+    "num_exoneracoes": 25,
+    "num_nomeacoes": 190
   }
 }

--- a/docs/site/dados/inicial/barra-de-santo-antonio-inicial.json
+++ b/docs/site/dados/inicial/barra-de-santo-antonio-inicial.json
@@ -11,10 +11,15 @@
       "num_diarios": 101,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 32,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 147,
+    "num_diarios": 179,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/barra-de-sao-miguel-inicial.json
+++ b/docs/site/dados/inicial/barra-de-sao-miguel-inicial.json
@@ -2,20 +2,25 @@
   "id": "barra-de-sao-miguel",
   "nome": "BARRA DE SÃO MIGUEL",
   "detalhe": {
+    "2021": {
+      "num_diarios": 110,
+      "num_nomeacoes": 6,
+      "num_exoneracoes": 0
+    },
     "2022": {
       "num_diarios": 161,
       "num_nomeacoes": 28,
       "num_exoneracoes": 1
     },
-    "2021": {
-      "num_diarios": 110,
-      "num_nomeacoes": 6,
-      "num_exoneracoes": 0
+    "2023": {
+      "num_diarios": 46,
+      "num_nomeacoes": 26,
+      "num_exoneracoes": 17
     }
   },
   "resumo": {
-    "num_diarios": 271,
-    "num_exoneracoes": 1,
-    "num_nomeacoes": 34
+    "num_diarios": 317,
+    "num_exoneracoes": 18,
+    "num_nomeacoes": 60
   }
 }

--- a/docs/site/dados/inicial/batalha-inicial.json
+++ b/docs/site/dados/inicial/batalha-inicial.json
@@ -2,8 +2,23 @@
   "id": "batalha",
   "nome": "BATALHA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 95,
+    "2015": {
+      "num_diarios": 26,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 33,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 66,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 73,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +26,20 @@
       "num_diarios": 95,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 95,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 30,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 190,
+    "num_diarios": 418,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/belem-inicial.json
+++ b/docs/site/dados/inicial/belem-inicial.json
@@ -2,8 +2,13 @@
   "id": "belem",
   "nome": "BELÉM",
   "detalhe": {
-    "2022": {
-      "num_diarios": 71,
+    "2017": {
+      "num_diarios": 19,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 65,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 82,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 71,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 153,
+    "num_diarios": 268,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/belo-monte-inicial.json
+++ b/docs/site/dados/inicial/belo-monte-inicial.json
@@ -2,8 +2,13 @@
   "id": "belo-monte",
   "nome": "BELO MONTE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 97,
+    "2017": {
+      "num_diarios": 34,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 46,
       "num_nomeacoes": 0,
       "num_exoneracoes": 3
     },
@@ -11,11 +16,21 @@
       "num_diarios": 72,
       "num_nomeacoes": 20,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 97,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 3
+    },
+    "2023": {
+      "num_diarios": 44,
+      "num_nomeacoes": 2,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 169,
-    "num_exoneracoes": 6,
-    "num_nomeacoes": 20
+    "num_diarios": 293,
+    "num_exoneracoes": 9,
+    "num_nomeacoes": 22
   }
 }

--- a/docs/site/dados/inicial/branquinha-inicial.json
+++ b/docs/site/dados/inicial/branquinha-inicial.json
@@ -2,8 +2,8 @@
   "id": "branquinha",
   "nome": "BRANQUINHA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 189,
+    "2020": {
+      "num_diarios": 25,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,11 +11,21 @@
       "num_diarios": 183,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 189,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 55,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 372,
+    "num_diarios": 452,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 0
+    "num_nomeacoes": 1
   }
 }

--- a/docs/site/dados/inicial/cacimbinhas-inicial.json
+++ b/docs/site/dados/inicial/cacimbinhas-inicial.json
@@ -2,20 +2,40 @@
   "id": "cacimbinhas",
   "nome": "CACIMBINHAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 147,
-      "num_nomeacoes": 3,
-      "num_exoneracoes": 3
+    "2016": {
+      "num_diarios": 42,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 82,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 109,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 138,
       "num_nomeacoes": 4,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 147,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 3
+    },
+    "2023": {
+      "num_diarios": 36,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 285,
+    "num_diarios": 554,
     "num_exoneracoes": 3,
-    "num_nomeacoes": 7
+    "num_nomeacoes": 10
   }
 }

--- a/docs/site/dados/inicial/cajueiro-inicial.json
+++ b/docs/site/dados/inicial/cajueiro-inicial.json
@@ -2,6 +2,16 @@
   "id": "cajueiro",
   "nome": "CAJUEIRO",
   "detalhe": {
+    "2017": {
+      "num_diarios": 1,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 44,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 76,
       "num_nomeacoes": 0,
@@ -11,10 +21,15 @@
       "num_diarios": 81,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 23,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 157,
+    "num_diarios": 225,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/campestre-inicial.json
+++ b/docs/site/dados/inicial/campestre-inicial.json
@@ -2,20 +2,35 @@
   "id": "campestre",
   "nome": "CAMPESTRE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 110,
+    "2017": {
+      "num_diarios": 41,
       "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 25,
+      "num_nomeacoes": 3,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 63,
       "num_nomeacoes": 14,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 110,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 35,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 173,
+    "num_diarios": 274,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 14
+    "num_nomeacoes": 17
   }
 }

--- a/docs/site/dados/inicial/campo-alegre-inicial.json
+++ b/docs/site/dados/inicial/campo-alegre-inicial.json
@@ -2,20 +2,45 @@
   "id": "campo-alegre",
   "nome": "CAMPO ALEGRE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 213,
+    "2015": {
+      "num_diarios": 34,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 54,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 105,
       "num_nomeacoes": 25,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 186,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 190,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 213,
+      "num_nomeacoes": 25,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 63,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 403,
+    "num_diarios": 845,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 25
+    "num_nomeacoes": 50
   }
 }

--- a/docs/site/dados/inicial/campo-alegre-setor-de-licitacoes-inicial.json
+++ b/docs/site/dados/inicial/campo-alegre-setor-de-licitacoes-inicial.json
@@ -1,0 +1,16 @@
+{
+  "id": "campo-alegre-setor-de-licitacoes",
+  "nome": "CAMPO ALEGRE SETOR DE LICITAÇÕES",
+  "detalhe": {
+    "2023": {
+      "num_diarios": 1,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    }
+  },
+  "resumo": {
+    "num_diarios": 1,
+    "num_exoneracoes": 0,
+    "num_nomeacoes": 0
+  }
+}

--- a/docs/site/dados/inicial/campo-grande-inicial.json
+++ b/docs/site/dados/inicial/campo-grande-inicial.json
@@ -2,6 +2,16 @@
   "id": "campo-grande",
   "nome": "CAMPO GRANDE",
   "detalhe": {
+    "2017": {
+      "num_diarios": 14,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 28,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 28,
       "num_nomeacoes": 0,
@@ -11,11 +21,16 @@
       "num_diarios": 33,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 9,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 61,
+    "num_diarios": 112,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 0
+    "num_nomeacoes": 1
   }
 }

--- a/docs/site/dados/inicial/canapi-inicial.json
+++ b/docs/site/dados/inicial/canapi-inicial.json
@@ -2,8 +2,8 @@
   "id": "canapi",
   "nome": "CANAPI",
   "detalhe": {
-    "2022": {
-      "num_diarios": 181,
+    "2020": {
+      "num_diarios": 118,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 155,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 181,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 58,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 336,
+    "num_diarios": 512,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/capela-inicial.json
+++ b/docs/site/dados/inicial/capela-inicial.json
@@ -2,8 +2,8 @@
   "id": "capela",
   "nome": "CAPELA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 52,
+    "2020": {
+      "num_diarios": 26,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 50,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 52,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 21,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 102,
+    "num_diarios": 149,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/carneiros-inicial.json
+++ b/docs/site/dados/inicial/carneiros-inicial.json
@@ -2,8 +2,13 @@
   "id": "carneiros",
   "nome": "CARNEIROS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 98,
+    "2017": {
+      "num_diarios": 66,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 80,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 84,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 98,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 182,
+    "num_diarios": 359,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/cha-preta-inicial.json
+++ b/docs/site/dados/inicial/cha-preta-inicial.json
@@ -2,19 +2,24 @@
   "id": "cha-preta",
   "nome": "CHÃ PRETA",
   "detalhe": {
+    "2021": {
+      "num_diarios": 45,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2022": {
       "num_diarios": 105,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
-    "2021": {
-      "num_diarios": 45,
+    "2023": {
+      "num_diarios": 36,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 150,
+    "num_diarios": 186,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/coite-do-noia-inicial.json
+++ b/docs/site/dados/inicial/coite-do-noia-inicial.json
@@ -2,19 +2,34 @@
   "id": "coite-do-noia",
   "nome": "COITÉ DO NÓIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 128,
-      "num_nomeacoes": 6,
+    "2017": {
+      "num_diarios": 16,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 121,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 81,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 128,
+      "num_nomeacoes": 6,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 43,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 209,
+    "num_diarios": 389,
     "num_exoneracoes": 0,
     "num_nomeacoes": 6
   }

--- a/docs/site/dados/inicial/colonia-leopoldina-inicial.json
+++ b/docs/site/dados/inicial/colonia-leopoldina-inicial.json
@@ -2,6 +2,11 @@
   "id": "colonia-leopoldina",
   "nome": "COLÔNIA LEOPOLDINA",
   "detalhe": {
+    "2020": {
+      "num_diarios": 103,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 109,
       "num_nomeacoes": 0,
@@ -11,11 +16,16 @@
       "num_diarios": 121,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 41,
+      "num_nomeacoes": 38,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 230,
+    "num_diarios": 374,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 0
+    "num_nomeacoes": 38
   }
 }

--- a/docs/site/dados/inicial/coqueiro-seco-inicial.json
+++ b/docs/site/dados/inicial/coqueiro-seco-inicial.json
@@ -2,8 +2,8 @@
   "id": "coqueiro-seco",
   "nome": "COQUEIRO SECO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 86,
+    "2020": {
+      "num_diarios": 84,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 77,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 86,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 163,
+    "num_diarios": 278,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/coruripe-inicial.json
+++ b/docs/site/dados/inicial/coruripe-inicial.json
@@ -2,6 +2,26 @@
   "id": "coruripe",
   "nome": "CORURIPE",
   "detalhe": {
+    "2015": {
+      "num_diarios": 27,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 73,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 102,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 102,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 150,
       "num_nomeacoes": 6,
@@ -11,11 +31,14 @@
       "num_diarios": 5,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 2
     }
   },
   "resumo": {
-    "num_diarios": 155,
+    "num_diarios": 461,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 6
+    "num_nomeacoes": 9
   }
 }

--- a/docs/site/dados/inicial/craibas-inicial.json
+++ b/docs/site/dados/inicial/craibas-inicial.json
@@ -2,20 +2,35 @@
   "id": "craibas",
   "nome": "CRAÍBAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 174,
-      "num_nomeacoes": 1,
+    "2017": {
+      "num_diarios": 25,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 50,
+      "num_nomeacoes": 4,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 138,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 174,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 53,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 312,
+    "num_diarios": 440,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 1
+    "num_nomeacoes": 5
   }
 }

--- a/docs/site/dados/inicial/delmiro-gouveia-inicial.json
+++ b/docs/site/dados/inicial/delmiro-gouveia-inicial.json
@@ -2,20 +2,30 @@
   "id": "delmiro-gouveia",
   "nome": "DELMIRO GOUVEIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 241,
-      "num_nomeacoes": 456,
-      "num_exoneracoes": 107
+    "2020": {
+      "num_diarios": 163,
+      "num_nomeacoes": 22,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 196,
       "num_nomeacoes": 3,
       "num_exoneracoes": 15
+    },
+    "2022": {
+      "num_diarios": 241,
+      "num_nomeacoes": 456,
+      "num_exoneracoes": 107
+    },
+    "2023": {
+      "num_diarios": 68,
+      "num_nomeacoes": 140,
+      "num_exoneracoes": 27
     }
   },
   "resumo": {
-    "num_diarios": 437,
-    "num_exoneracoes": 122,
-    "num_nomeacoes": 459
+    "num_diarios": 668,
+    "num_exoneracoes": 149,
+    "num_nomeacoes": 621
   }
 }

--- a/docs/site/dados/inicial/dois-riachos-inicial.json
+++ b/docs/site/dados/inicial/dois-riachos-inicial.json
@@ -2,8 +2,13 @@
   "id": "dois-riachos",
   "nome": "DOIS RIACHOS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 129,
+    "2017": {
+      "num_diarios": 33,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 59,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,11 +16,21 @@
       "num_diarios": 101,
       "num_nomeacoes": 3,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 129,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 43,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 230,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 3
+    "num_diarios": 365,
+    "num_exoneracoes": 1,
+    "num_nomeacoes": 4
   }
 }

--- a/docs/site/dados/inicial/estrela-de-alagoas-inicial.json
+++ b/docs/site/dados/inicial/estrela-de-alagoas-inicial.json
@@ -11,10 +11,15 @@
       "num_diarios": 88,
       "num_nomeacoes": 0,
       "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 34,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 151,
+    "num_diarios": 185,
     "num_exoneracoes": 1,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/feira-grande-inicial.json
+++ b/docs/site/dados/inicial/feira-grande-inicial.json
@@ -2,8 +2,8 @@
   "id": "feira-grande",
   "nome": "FEIRA GRANDE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 103,
+    "2020": {
+      "num_diarios": 92,
       "num_nomeacoes": 0,
       "num_exoneracoes": 1
     },
@@ -11,11 +11,21 @@
       "num_diarios": 72,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 103,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 34,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 175,
-    "num_exoneracoes": 1,
+    "num_diarios": 301,
+    "num_exoneracoes": 2,
     "num_nomeacoes": 0
   }
 }

--- a/docs/site/dados/inicial/feliz-deserto-inicial.json
+++ b/docs/site/dados/inicial/feliz-deserto-inicial.json
@@ -2,6 +2,11 @@
   "id": "feliz-deserto",
   "nome": "FELIZ DESERTO",
   "detalhe": {
+    "2020": {
+      "num_diarios": 61,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 59,
       "num_nomeacoes": 37,
@@ -11,11 +16,16 @@
       "num_diarios": 73,
       "num_nomeacoes": 0,
       "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 21,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 132,
+    "num_diarios": 214,
     "num_exoneracoes": 2,
-    "num_nomeacoes": 37
+    "num_nomeacoes": 38
   }
 }

--- a/docs/site/dados/inicial/flexeiras-inicial.json
+++ b/docs/site/dados/inicial/flexeiras-inicial.json
@@ -2,8 +2,8 @@
   "id": "flexeiras",
   "nome": "FLEXEIRAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 95,
+    "2020": {
+      "num_diarios": 20,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,11 +11,21 @@
       "num_diarios": 55,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 95,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 40,
+      "num_nomeacoes": 18,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 150,
+    "num_diarios": 210,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 0
+    "num_nomeacoes": 18
   }
 }

--- a/docs/site/dados/inicial/geral-inicial.json
+++ b/docs/site/dados/inicial/geral-inicial.json
@@ -1,20 +1,50 @@
 {
   "id": "geral",
   "detalhe": {
-    "2022": {
-      "num_diarios": 11481,
-      "num_nomeacoes": 231734,
-      "num_exoneracoes": 50388
+    "2014": {
+      "num_diarios": 24,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2015": {
+      "num_diarios": 357,
+      "num_nomeacoes": 304,
+      "num_exoneracoes": 187
+    },
+    "2016": {
+      "num_diarios": 834,
+      "num_nomeacoes": 1848,
+      "num_exoneracoes": 1031
+    },
+    "2017": {
+      "num_diarios": 1963,
+      "num_nomeacoes": 18263,
+      "num_exoneracoes": 2369
+    },
+    "2020": {
+      "num_diarios": 6957,
+      "num_nomeacoes": 83423,
+      "num_exoneracoes": 43714
     },
     "2021": {
       "num_diarios": 9600,
-      "num_nomeacoes": 202481,
-      "num_exoneracoes": 26851
+      "num_nomeacoes": 286324,
+      "num_exoneracoes": 23549
+    },
+    "2022": {
+      "num_diarios": 11480,
+      "num_nomeacoes": 289384,
+      "num_exoneracoes": 50559
+    },
+    "2023": {
+      "num_diarios": 3603,
+      "num_nomeacoes": 44279,
+      "num_exoneracoes": 6905
     }
   },
   "resumo": {
-    "num_diarios": 21081,
-    "num_exoneracoes": 77239,
-    "num_nomeacoes": 434215
+    "num_diarios": 34818,
+    "num_exoneracoes": 128314,
+    "num_nomeacoes": 723825
   }
 }

--- a/docs/site/dados/inicial/girau-do-ponciano-inicial.json
+++ b/docs/site/dados/inicial/girau-do-ponciano-inicial.json
@@ -2,15 +2,25 @@
   "id": "girau-do-ponciano",
   "nome": "GIRAU DO PONCIANO",
   "detalhe": {
+    "2020": {
+      "num_diarios": 129,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 1
+    },
     "2021": {
       "num_diarios": 18,
       "num_nomeacoes": 17,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 27,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 18,
-    "num_exoneracoes": 0,
+    "num_diarios": 174,
+    "num_exoneracoes": 1,
     "num_nomeacoes": 17
   }
 }

--- a/docs/site/dados/inicial/ibateguara-inicial.json
+++ b/docs/site/dados/inicial/ibateguara-inicial.json
@@ -2,8 +2,8 @@
   "id": "ibateguara",
   "nome": "IBATEGUARA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 137,
+    "2020": {
+      "num_diarios": 80,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 137,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 137,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 41,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 274,
+    "num_diarios": 395,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/igaci-inicial.json
+++ b/docs/site/dados/inicial/igaci-inicial.json
@@ -11,10 +11,15 @@
       "num_diarios": 102,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 29,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 124,
+    "num_diarios": 153,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/igreja-nova-inicial.json
+++ b/docs/site/dados/inicial/igreja-nova-inicial.json
@@ -2,19 +2,29 @@
   "id": "igreja-nova",
   "nome": "IGREJA NOVA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 126,
-      "num_nomeacoes": 9,
+    "2020": {
+      "num_diarios": 86,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 106,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 126,
+      "num_nomeacoes": 9,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 44,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 232,
+    "num_diarios": 362,
     "num_exoneracoes": 0,
     "num_nomeacoes": 9
   }

--- a/docs/site/dados/inicial/inhapi-inicial.json
+++ b/docs/site/dados/inicial/inhapi-inicial.json
@@ -2,20 +2,40 @@
   "id": "inhapi",
   "nome": "INHAPI",
   "detalhe": {
-    "2022": {
-      "num_diarios": 202,
-      "num_nomeacoes": 46,
-      "num_exoneracoes": 18
+    "2016": {
+      "num_diarios": 50,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 31
+    },
+    "2017": {
+      "num_diarios": 118,
+      "num_nomeacoes": 65,
+      "num_exoneracoes": 23
+    },
+    "2020": {
+      "num_diarios": 170,
+      "num_nomeacoes": 29,
+      "num_exoneracoes": 25
     },
     "2021": {
       "num_diarios": 192,
       "num_nomeacoes": 85,
       "num_exoneracoes": 20
+    },
+    "2022": {
+      "num_diarios": 202,
+      "num_nomeacoes": 46,
+      "num_exoneracoes": 18
+    },
+    "2023": {
+      "num_diarios": 61,
+      "num_nomeacoes": 10,
+      "num_exoneracoes": 6
     }
   },
   "resumo": {
-    "num_diarios": 394,
-    "num_exoneracoes": 38,
-    "num_nomeacoes": 131
+    "num_diarios": 793,
+    "num_exoneracoes": 123,
+    "num_nomeacoes": 235
   }
 }

--- a/docs/site/dados/inicial/jacare-dos-homens-inicial.json
+++ b/docs/site/dados/inicial/jacare-dos-homens-inicial.json
@@ -2,8 +2,8 @@
   "id": "jacare-dos-homens",
   "nome": "JACARÉ DOS HOMENS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 56,
+    "2020": {
+      "num_diarios": 43,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 57,
       "num_nomeacoes": 10,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 56,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 30,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 113,
+    "num_diarios": 186,
     "num_exoneracoes": 0,
     "num_nomeacoes": 10
   }

--- a/docs/site/dados/inicial/jacuipe-inicial.json
+++ b/docs/site/dados/inicial/jacuipe-inicial.json
@@ -2,6 +2,11 @@
   "id": "jacuipe",
   "nome": "JACUÍPE",
   "detalhe": {
+    "2020": {
+      "num_diarios": 24,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 42,
       "num_nomeacoes": 0,
@@ -11,10 +16,15 @@
       "num_diarios": 68,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 16,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 110,
+    "num_diarios": 150,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/japaratinga-inicial.json
+++ b/docs/site/dados/inicial/japaratinga-inicial.json
@@ -2,19 +2,34 @@
   "id": "japaratinga",
   "nome": "JAPARATINGA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 75,
-      "num_nomeacoes": 17,
-      "num_exoneracoes": 1
+    "2017": {
+      "num_diarios": 21,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 3,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 68,
       "num_nomeacoes": 79,
       "num_exoneracoes": 9
+    },
+    "2022": {
+      "num_diarios": 75,
+      "num_nomeacoes": 17,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 24,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 143,
+    "num_diarios": 191,
     "num_exoneracoes": 10,
     "num_nomeacoes": 96
   }

--- a/docs/site/dados/inicial/jaramataia-inicial.json
+++ b/docs/site/dados/inicial/jaramataia-inicial.json
@@ -2,8 +2,13 @@
   "id": "jaramataia",
   "nome": "JARAMATAIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 41,
+    "2017": {
+      "num_diarios": 17,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 115,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 37,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 41,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 8,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 78,
+    "num_diarios": 218,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/jequia-da-praia-inicial.json
+++ b/docs/site/dados/inicial/jequia-da-praia-inicial.json
@@ -2,20 +2,45 @@
   "id": "jequia-da-praia",
   "nome": "JEQUIÁ DA PRAIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 153,
-      "num_nomeacoes": 24,
-      "num_exoneracoes": 15
+    "2015": {
+      "num_diarios": 61,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 103,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 101,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 108,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 1
     },
     "2021": {
       "num_diarios": 153,
       "num_nomeacoes": 66,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 153,
+      "num_nomeacoes": 24,
+      "num_exoneracoes": 15
+    },
+    "2023": {
+      "num_diarios": 48,
+      "num_nomeacoes": 6,
+      "num_exoneracoes": 7
     }
   },
   "resumo": {
-    "num_diarios": 306,
-    "num_exoneracoes": 18,
-    "num_nomeacoes": 90
+    "num_diarios": 727,
+    "num_exoneracoes": 26,
+    "num_nomeacoes": 98
   }
 }

--- a/docs/site/dados/inicial/joaquim-gomes-inicial.json
+++ b/docs/site/dados/inicial/joaquim-gomes-inicial.json
@@ -2,20 +2,30 @@
   "id": "joaquim-gomes",
   "nome": "JOAQUIM GOMES",
   "detalhe": {
-    "2022": {
-      "num_diarios": 109,
-      "num_nomeacoes": 44,
-      "num_exoneracoes": 1
+    "2020": {
+      "num_diarios": 78,
+      "num_nomeacoes": 108,
+      "num_exoneracoes": 5
     },
     "2021": {
       "num_diarios": 82,
       "num_nomeacoes": 33,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 109,
+      "num_nomeacoes": 44,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 36,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 191,
-    "num_exoneracoes": 1,
-    "num_nomeacoes": 77
+    "num_diarios": 305,
+    "num_exoneracoes": 7,
+    "num_nomeacoes": 186
   }
 }

--- a/docs/site/dados/inicial/jundia-inicial.json
+++ b/docs/site/dados/inicial/jundia-inicial.json
@@ -2,19 +2,24 @@
   "id": "jundia",
   "nome": "JUNDIÁ",
   "detalhe": {
+    "2021": {
+      "num_diarios": 32,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2022": {
       "num_diarios": 57,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
-    "2021": {
-      "num_diarios": 32,
+    "2023": {
+      "num_diarios": 18,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 89,
+    "num_diarios": 107,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/junqueiro-inicial.json
+++ b/docs/site/dados/inicial/junqueiro-inicial.json
@@ -2,20 +2,40 @@
   "id": "junqueiro",
   "nome": "JUNQUEIRO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 199,
-      "num_nomeacoes": 41,
-      "num_exoneracoes": 6
+    "2016": {
+      "num_diarios": 46,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 81,
+      "num_nomeacoes": 133,
+      "num_exoneracoes": 15
+    },
+    "2020": {
+      "num_diarios": 135,
+      "num_nomeacoes": 51,
+      "num_exoneracoes": 11
     },
     "2021": {
       "num_diarios": 179,
       "num_nomeacoes": 149,
       "num_exoneracoes": 6
+    },
+    "2022": {
+      "num_diarios": 199,
+      "num_nomeacoes": 41,
+      "num_exoneracoes": 6
+    },
+    "2023": {
+      "num_diarios": 54,
+      "num_nomeacoes": 28,
+      "num_exoneracoes": 29
     }
   },
   "resumo": {
-    "num_diarios": 378,
-    "num_exoneracoes": 12,
-    "num_nomeacoes": 190
+    "num_diarios": 694,
+    "num_exoneracoes": 67,
+    "num_nomeacoes": 402
   }
 }

--- a/docs/site/dados/inicial/lagoa-da-canoa-inicial.json
+++ b/docs/site/dados/inicial/lagoa-da-canoa-inicial.json
@@ -2,20 +2,35 @@
   "id": "lagoa-da-canoa",
   "nome": "LAGOA DA CANOA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 121,
-      "num_nomeacoes": 0,
+    "2017": {
+      "num_diarios": 73,
+      "num_nomeacoes": 3,
       "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 102,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 2
     },
     "2021": {
       "num_diarios": 120,
       "num_nomeacoes": 43,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 121,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 50,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 241,
-    "num_exoneracoes": 3,
-    "num_nomeacoes": 43
+    "num_diarios": 466,
+    "num_exoneracoes": 6,
+    "num_nomeacoes": 47
   }
 }

--- a/docs/site/dados/inicial/limoeiro-de-anadia-inicial.json
+++ b/docs/site/dados/inicial/limoeiro-de-anadia-inicial.json
@@ -2,8 +2,8 @@
   "id": "limoeiro-de-anadia",
   "nome": "LIMOEIRO DE ANADIA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 134,
+    "2020": {
+      "num_diarios": 80,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 147,
       "num_nomeacoes": 30,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 134,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 47,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 281,
+    "num_diarios": 408,
     "num_exoneracoes": 0,
     "num_nomeacoes": 30
   }

--- a/docs/site/dados/inicial/major-izidoro-inicial.json
+++ b/docs/site/dados/inicial/major-izidoro-inicial.json
@@ -2,20 +2,30 @@
   "id": "major-izidoro",
   "nome": "MAJOR IZIDORO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 115,
-      "num_nomeacoes": 1,
+    "2020": {
+      "num_diarios": 95,
+      "num_nomeacoes": 12,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 117,
       "num_nomeacoes": 6,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 115,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 36,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 232,
+    "num_diarios": 363,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 7
+    "num_nomeacoes": 19
   }
 }

--- a/docs/site/dados/inicial/mar-vermelho-inicial.json
+++ b/docs/site/dados/inicial/mar-vermelho-inicial.json
@@ -2,6 +2,16 @@
   "id": "mar-vermelho",
   "nome": "MAR VERMELHO",
   "detalhe": {
+    "2017": {
+      "num_diarios": 23,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 60,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 90,
       "num_nomeacoes": 0,
@@ -11,10 +21,15 @@
       "num_diarios": 101,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 191,
+    "num_diarios": 305,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/maragogi-inicial.json
+++ b/docs/site/dados/inicial/maragogi-inicial.json
@@ -2,20 +2,35 @@
   "id": "maragogi",
   "nome": "MARAGOGI",
   "detalhe": {
-    "2022": {
-      "num_diarios": 199,
-      "num_nomeacoes": 386,
-      "num_exoneracoes": 56
+    "2017": {
+      "num_diarios": 45,
+      "num_nomeacoes": 25,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 145,
+      "num_nomeacoes": 22,
+      "num_exoneracoes": 1
     },
     "2021": {
       "num_diarios": 172,
       "num_nomeacoes": 406,
       "num_exoneracoes": 80
+    },
+    "2022": {
+      "num_diarios": 199,
+      "num_nomeacoes": 386,
+      "num_exoneracoes": 56
+    },
+    "2023": {
+      "num_diarios": 55,
+      "num_nomeacoes": 343,
+      "num_exoneracoes": 44
     }
   },
   "resumo": {
-    "num_diarios": 371,
-    "num_exoneracoes": 136,
-    "num_nomeacoes": 792
+    "num_diarios": 616,
+    "num_exoneracoes": 181,
+    "num_nomeacoes": 1182
   }
 }

--- a/docs/site/dados/inicial/maravilha-inicial.json
+++ b/docs/site/dados/inicial/maravilha-inicial.json
@@ -2,20 +2,35 @@
   "id": "maravilha",
   "nome": "MARAVILHA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 167,
-      "num_nomeacoes": 71,
-      "num_exoneracoes": 10
+    "2017": {
+      "num_diarios": 44,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 97,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 2
     },
     "2021": {
       "num_diarios": 106,
       "num_nomeacoes": 36,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 167,
+      "num_nomeacoes": 71,
+      "num_exoneracoes": 10
+    },
+    "2023": {
+      "num_diarios": 49,
+      "num_nomeacoes": 30,
+      "num_exoneracoes": 3
     }
   },
   "resumo": {
-    "num_diarios": 273,
-    "num_exoneracoes": 13,
-    "num_nomeacoes": 107
+    "num_diarios": 463,
+    "num_exoneracoes": 18,
+    "num_nomeacoes": 138
   }
 }

--- a/docs/site/dados/inicial/marechal-deodoro-inicial.json
+++ b/docs/site/dados/inicial/marechal-deodoro-inicial.json
@@ -2,20 +2,30 @@
   "id": "marechal-deodoro",
   "nome": "MARECHAL DEODORO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 242,
-      "num_nomeacoes": 102,
-      "num_exoneracoes": 15
+    "2020": {
+      "num_diarios": 238,
+      "num_nomeacoes": 122,
+      "num_exoneracoes": 130
     },
     "2021": {
       "num_diarios": 238,
       "num_nomeacoes": 413,
       "num_exoneracoes": 36
+    },
+    "2022": {
+      "num_diarios": 242,
+      "num_nomeacoes": 102,
+      "num_exoneracoes": 15
+    },
+    "2023": {
+      "num_diarios": 66,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 480,
-    "num_exoneracoes": 51,
-    "num_nomeacoes": 515
+    "num_diarios": 784,
+    "num_exoneracoes": 181,
+    "num_nomeacoes": 637
   }
 }

--- a/docs/site/dados/inicial/maribondo-inicial.json
+++ b/docs/site/dados/inicial/maribondo-inicial.json
@@ -2,20 +2,45 @@
   "id": "maribondo",
   "nome": "MARIBONDO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 96,
-      "num_nomeacoes": 18,
+    "2015": {
+      "num_diarios": 38,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 39,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 7,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 36,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 102,
       "num_nomeacoes": 51,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 96,
+      "num_nomeacoes": 18,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 26,
+      "num_nomeacoes": 7,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 198,
+    "num_diarios": 344,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 69
+    "num_nomeacoes": 76
   }
 }

--- a/docs/site/dados/inicial/mata-grande-inicial.json
+++ b/docs/site/dados/inicial/mata-grande-inicial.json
@@ -2,20 +2,30 @@
   "id": "mata-grande",
   "nome": "MATA GRANDE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 137,
-      "num_nomeacoes": 283,
-      "num_exoneracoes": 16
+    "2020": {
+      "num_diarios": 96,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 84,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 137,
+      "num_nomeacoes": 283,
+      "num_exoneracoes": 16
+    },
+    "2023": {
+      "num_diarios": 41,
+      "num_nomeacoes": 2,
+      "num_exoneracoes": 2
     }
   },
   "resumo": {
-    "num_diarios": 221,
-    "num_exoneracoes": 16,
-    "num_nomeacoes": 283
+    "num_diarios": 358,
+    "num_exoneracoes": 18,
+    "num_nomeacoes": 285
   }
 }

--- a/docs/site/dados/inicial/matriz-de-camaragibe-inicial.json
+++ b/docs/site/dados/inicial/matriz-de-camaragibe-inicial.json
@@ -1,0 +1,16 @@
+{
+  "id": "matriz-de-camaragibe",
+  "nome": "MATRIZ DE CAMARAGIBE",
+  "detalhe": {
+    "2023": {
+      "num_diarios": 9,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    }
+  },
+  "resumo": {
+    "num_diarios": 9,
+    "num_exoneracoes": 0,
+    "num_nomeacoes": 0
+  }
+}

--- a/docs/site/dados/inicial/messias-inicial.json
+++ b/docs/site/dados/inicial/messias-inicial.json
@@ -2,20 +2,35 @@
   "id": "messias",
   "nome": "MESSIAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 137,
+    "2017": {
+      "num_diarios": 9,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 54,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 2
     },
     "2021": {
       "num_diarios": 107,
       "num_nomeacoes": 10,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 137,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 35,
+      "num_nomeacoes": 2,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 244,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 10
+    "num_diarios": 342,
+    "num_exoneracoes": 2,
+    "num_nomeacoes": 15
   }
 }

--- a/docs/site/dados/inicial/minador-do-negrao-inicial.json
+++ b/docs/site/dados/inicial/minador-do-negrao-inicial.json
@@ -2,20 +2,35 @@
   "id": "minador-do-negrao",
   "nome": "MINADOR DO NEGRÃO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 161,
-      "num_nomeacoes": 35,
-      "num_exoneracoes": 50
+    "2017": {
+      "num_diarios": 9,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 51,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 146,
       "num_nomeacoes": 88,
       "num_exoneracoes": 8
+    },
+    "2022": {
+      "num_diarios": 161,
+      "num_nomeacoes": 35,
+      "num_exoneracoes": 50
+    },
+    "2023": {
+      "num_diarios": 47,
+      "num_nomeacoes": 5,
+      "num_exoneracoes": 11
     }
   },
   "resumo": {
-    "num_diarios": 307,
-    "num_exoneracoes": 58,
-    "num_nomeacoes": 123
+    "num_diarios": 414,
+    "num_exoneracoes": 69,
+    "num_nomeacoes": 128
   }
 }

--- a/docs/site/dados/inicial/monteiropolis-inicial.json
+++ b/docs/site/dados/inicial/monteiropolis-inicial.json
@@ -2,6 +2,16 @@
   "id": "monteiropolis",
   "nome": "MONTEIRÓPOLIS",
   "detalhe": {
+    "2017": {
+      "num_diarios": 4,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 41,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 61,
       "num_nomeacoes": 0,
@@ -11,10 +21,15 @@
       "num_diarios": 56,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 17,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 117,
+    "num_diarios": 179,
     "num_exoneracoes": 3,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/novo-lino-inicial.json
+++ b/docs/site/dados/inicial/novo-lino-inicial.json
@@ -2,20 +2,30 @@
   "id": "novo-lino",
   "nome": "NOVO LINO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 147,
-      "num_nomeacoes": 9,
-      "num_exoneracoes": 1
+    "2020": {
+      "num_diarios": 36,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 80,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 147,
+      "num_nomeacoes": 9,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 46,
+      "num_nomeacoes": 66,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 227,
+    "num_diarios": 309,
     "num_exoneracoes": 1,
-    "num_nomeacoes": 9
+    "num_nomeacoes": 75
   }
 }

--- a/docs/site/dados/inicial/olho-d agua-do-casado-inicial.json
+++ b/docs/site/dados/inicial/olho-d agua-do-casado-inicial.json
@@ -2,20 +2,30 @@
   "id": "olho-d agua-do-casado",
   "nome": "OLHO D´AGUA DO CASADO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 157,
-      "num_nomeacoes": 8,
-      "num_exoneracoes": 3
+    "2020": {
+      "num_diarios": 99,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 89,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 157,
+      "num_nomeacoes": 8,
+      "num_exoneracoes": 3
+    },
+    "2023": {
+      "num_diarios": 45,
+      "num_nomeacoes": 9,
+      "num_exoneracoes": 3
     }
   },
   "resumo": {
-    "num_diarios": 246,
-    "num_exoneracoes": 3,
-    "num_nomeacoes": 8
+    "num_diarios": 390,
+    "num_exoneracoes": 6,
+    "num_nomeacoes": 17
   }
 }

--- a/docs/site/dados/inicial/olho-d agua-grande-inicial.json
+++ b/docs/site/dados/inicial/olho-d agua-grande-inicial.json
@@ -11,10 +11,15 @@
       "num_diarios": 19,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 9,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 33,
+    "num_diarios": 42,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/olho-d'agua-das-flores-inicial.json
+++ b/docs/site/dados/inicial/olho-d'agua-das-flores-inicial.json
@@ -2,20 +2,35 @@
   "id": "olho-d'agua-das-flores",
   "nome": "OLHO D'ÁGUA DAS FLORES",
   "detalhe": {
-    "2022": {
-      "num_diarios": 175,
+    "2017": {
+      "num_diarios": 16,
       "num_nomeacoes": 0,
-      "num_exoneracoes": 11
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 90,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 1
     },
     "2021": {
       "num_diarios": 106,
       "num_nomeacoes": 16,
       "num_exoneracoes": 4
+    },
+    "2022": {
+      "num_diarios": 175,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 11
+    },
+    "2023": {
+      "num_diarios": 51,
+      "num_nomeacoes": 16,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 281,
-    "num_exoneracoes": 15,
-    "num_nomeacoes": 16
+    "num_diarios": 438,
+    "num_exoneracoes": 16,
+    "num_nomeacoes": 32
   }
 }

--- a/docs/site/dados/inicial/olivenca-inicial.json
+++ b/docs/site/dados/inicial/olivenca-inicial.json
@@ -2,6 +2,16 @@
   "id": "olivenca",
   "nome": "OLIVENÇA",
   "detalhe": {
+    "2017": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 48,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 1
+    },
     "2021": {
       "num_diarios": 96,
       "num_nomeacoes": 1,
@@ -11,11 +21,16 @@
       "num_diarios": 118,
       "num_nomeacoes": 1,
       "num_exoneracoes": 5
+    },
+    "2023": {
+      "num_diarios": 37,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 214,
-    "num_exoneracoes": 5,
+    "num_diarios": 330,
+    "num_exoneracoes": 6,
     "num_nomeacoes": 2
   }
 }

--- a/docs/site/dados/inicial/ouro-branco-inicial.json
+++ b/docs/site/dados/inicial/ouro-branco-inicial.json
@@ -2,20 +2,25 @@
   "id": "ouro-branco",
   "nome": "OURO BRANCO",
   "detalhe": {
+    "2021": {
+      "num_diarios": 128,
+      "num_nomeacoes": 40,
+      "num_exoneracoes": 1
+    },
     "2022": {
       "num_diarios": 161,
       "num_nomeacoes": 15,
       "num_exoneracoes": 5
     },
-    "2021": {
-      "num_diarios": 128,
-      "num_nomeacoes": 40,
+    "2023": {
+      "num_diarios": 47,
+      "num_nomeacoes": 54,
       "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 289,
-    "num_exoneracoes": 6,
-    "num_nomeacoes": 55
+    "num_diarios": 336,
+    "num_exoneracoes": 7,
+    "num_nomeacoes": 109
   }
 }

--- a/docs/site/dados/inicial/palestina-inicial.json
+++ b/docs/site/dados/inicial/palestina-inicial.json
@@ -2,19 +2,39 @@
   "id": "palestina",
   "nome": "PALESTINA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 95,
+    "2016": {
+      "num_diarios": 23,
       "num_nomeacoes": 0,
-      "num_exoneracoes": 2
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 36,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 41,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 89,
       "num_nomeacoes": 2,
       "num_exoneracoes": 7
+    },
+    "2022": {
+      "num_diarios": 95,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 2
+    },
+    "2023": {
+      "num_diarios": 30,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 184,
+    "num_diarios": 314,
     "num_exoneracoes": 9,
     "num_nomeacoes": 2
   }

--- a/docs/site/dados/inicial/pao-de-acucar-inicial.json
+++ b/docs/site/dados/inicial/pao-de-acucar-inicial.json
@@ -2,20 +2,50 @@
   "id": "pao-de-acucar",
   "nome": "PÃO DE AÇÚCAR",
   "detalhe": {
-    "2022": {
-      "num_diarios": 147,
-      "num_nomeacoes": 60,
-      "num_exoneracoes": 16
+    "2014": {
+      "num_diarios": 17,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2015": {
+      "num_diarios": 56,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 57,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 49,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 67,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 111,
       "num_nomeacoes": 59,
       "num_exoneracoes": 5
+    },
+    "2022": {
+      "num_diarios": 147,
+      "num_nomeacoes": 60,
+      "num_exoneracoes": 16
+    },
+    "2023": {
+      "num_diarios": 41,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 258,
+    "num_diarios": 545,
     "num_exoneracoes": 21,
-    "num_nomeacoes": 119
+    "num_nomeacoes": 122
   }
 }

--- a/docs/site/dados/inicial/pariconha-inicial.json
+++ b/docs/site/dados/inicial/pariconha-inicial.json
@@ -2,20 +2,30 @@
   "id": "pariconha",
   "nome": "PARICONHA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 137,
-      "num_nomeacoes": 130,
-      "num_exoneracoes": 0
+    "2020": {
+      "num_diarios": 56,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 4
     },
     "2021": {
       "num_diarios": 64,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 137,
+      "num_nomeacoes": 130,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 50,
+      "num_nomeacoes": 26,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 201,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 130
+    "num_diarios": 307,
+    "num_exoneracoes": 4,
+    "num_nomeacoes": 156
   }
 }

--- a/docs/site/dados/inicial/passo-de-camaragibe-inicial.json
+++ b/docs/site/dados/inicial/passo-de-camaragibe-inicial.json
@@ -1,0 +1,16 @@
+{
+  "id": "passo-de-camaragibe",
+  "nome": "PASSO DE CAMARAGIBE",
+  "detalhe": {
+    "2023": {
+      "num_diarios": 21,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    }
+  },
+  "resumo": {
+    "num_diarios": 21,
+    "num_exoneracoes": 0,
+    "num_nomeacoes": 1
+  }
+}

--- a/docs/site/dados/inicial/paulo-jacinto-inicial.json
+++ b/docs/site/dados/inicial/paulo-jacinto-inicial.json
@@ -2,20 +2,35 @@
   "id": "paulo-jacinto",
   "nome": "PAULO JACINTO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 63,
+    "2015": {
+      "num_diarios": 7,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 140,
+      "num_nomeacoes": 26,
+      "num_exoneracoes": 9
     },
     "2021": {
       "num_diarios": 42,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 63,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 28,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 105,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 0
+    "num_diarios": 280,
+    "num_exoneracoes": 9,
+    "num_nomeacoes": 26
   }
 }

--- a/docs/site/dados/inicial/piacabucu-inicial.json
+++ b/docs/site/dados/inicial/piacabucu-inicial.json
@@ -2,19 +2,24 @@
   "id": "piacabucu",
   "nome": "PIAÇABUÇU",
   "detalhe": {
+    "2021": {
+      "num_diarios": 75,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2022": {
       "num_diarios": 113,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
-    "2021": {
-      "num_diarios": 75,
+    "2023": {
+      "num_diarios": 43,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 188,
+    "num_diarios": 231,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/pilar-inicial.json
+++ b/docs/site/dados/inicial/pilar-inicial.json
@@ -2,20 +2,30 @@
   "id": "pilar",
   "nome": "PILAR",
   "detalhe": {
-    "2022": {
-      "num_diarios": 231,
-      "num_nomeacoes": 3,
-      "num_exoneracoes": 11
+    "2020": {
+      "num_diarios": 187,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 6
     },
     "2021": {
       "num_diarios": 210,
       "num_nomeacoes": 0,
       "num_exoneracoes": 15
+    },
+    "2022": {
+      "num_diarios": 231,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 11
+    },
+    "2023": {
+      "num_diarios": 60,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 7
     }
   },
   "resumo": {
-    "num_diarios": 441,
-    "num_exoneracoes": 26,
+    "num_diarios": 688,
+    "num_exoneracoes": 39,
     "num_nomeacoes": 3
   }
 }

--- a/docs/site/dados/inicial/pindoba-inicial.json
+++ b/docs/site/dados/inicial/pindoba-inicial.json
@@ -2,7 +2,12 @@
   "id": "pindoba",
   "nome": "PINDOBA",
   "detalhe": {
-    "2022": {
+    "2017": {
+      "num_diarios": 38,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
       "num_diarios": 68,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
@@ -11,10 +16,20 @@
       "num_diarios": 81,
       "num_nomeacoes": 49,
       "num_exoneracoes": 1
+    },
+    "2022": {
+      "num_diarios": 68,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 30,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 149,
+    "num_diarios": 285,
     "num_exoneracoes": 1,
     "num_nomeacoes": 49
   }

--- a/docs/site/dados/inicial/piranhas-inicial.json
+++ b/docs/site/dados/inicial/piranhas-inicial.json
@@ -2,20 +2,30 @@
   "id": "piranhas",
   "nome": "PIRANHAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 153,
-      "num_nomeacoes": 24,
-      "num_exoneracoes": 18
+    "2020": {
+      "num_diarios": 102,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 142,
       "num_nomeacoes": 180,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 153,
+      "num_nomeacoes": 24,
+      "num_exoneracoes": 18
+    },
+    "2023": {
+      "num_diarios": 56,
+      "num_nomeacoes": 18,
+      "num_exoneracoes": 9
     }
   },
   "resumo": {
-    "num_diarios": 295,
-    "num_exoneracoes": 21,
-    "num_nomeacoes": 204
+    "num_diarios": 453,
+    "num_exoneracoes": 30,
+    "num_nomeacoes": 222
   }
 }

--- a/docs/site/dados/inicial/poco-das-trincheiras-inicial.json
+++ b/docs/site/dados/inicial/poco-das-trincheiras-inicial.json
@@ -2,20 +2,35 @@
   "id": "poco-das-trincheiras",
   "nome": "POÇO DAS TRINCHEIRAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 121,
-      "num_nomeacoes": 64,
-      "num_exoneracoes": 15
+    "2017": {
+      "num_diarios": 34,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 61,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 94,
       "num_nomeacoes": 2,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 121,
+      "num_nomeacoes": 64,
+      "num_exoneracoes": 15
+    },
+    "2023": {
+      "num_diarios": 37,
+      "num_nomeacoes": 29,
+      "num_exoneracoes": 23
     }
   },
   "resumo": {
-    "num_diarios": 215,
-    "num_exoneracoes": 15,
-    "num_nomeacoes": 66
+    "num_diarios": 347,
+    "num_exoneracoes": 38,
+    "num_nomeacoes": 95
   }
 }

--- a/docs/site/dados/inicial/porto-calvo-inicial.json
+++ b/docs/site/dados/inicial/porto-calvo-inicial.json
@@ -2,20 +2,30 @@
   "id": "porto-calvo",
   "nome": "PORTO CALVO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 132,
-      "num_nomeacoes": 0,
-      "num_exoneracoes": 0
+    "2020": {
+      "num_diarios": 50,
+      "num_nomeacoes": 29,
+      "num_exoneracoes": 4
     },
     "2021": {
       "num_diarios": 107,
       "num_nomeacoes": 1,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 132,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 49,
+      "num_nomeacoes": 29,
+      "num_exoneracoes": 3
     }
   },
   "resumo": {
-    "num_diarios": 239,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 1
+    "num_diarios": 338,
+    "num_exoneracoes": 7,
+    "num_nomeacoes": 59
   }
 }

--- a/docs/site/dados/inicial/porto-de-pedras-inicial.json
+++ b/docs/site/dados/inicial/porto-de-pedras-inicial.json
@@ -2,20 +2,35 @@
   "id": "porto-de-pedras",
   "nome": "PORTO DE PEDRAS",
   "detalhe": {
-    "2022": {
-      "num_diarios": 66,
-      "num_nomeacoes": 2,
+    "2017": {
+      "num_diarios": 25,
+      "num_nomeacoes": 1,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 38,
+      "num_nomeacoes": 3,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 72,
       "num_nomeacoes": 1,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 66,
+      "num_nomeacoes": 2,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 12,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 138,
+    "num_diarios": 213,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 3
+    "num_nomeacoes": 7
   }
 }

--- a/docs/site/dados/inicial/porto-real-do-colegio-inicial.json
+++ b/docs/site/dados/inicial/porto-real-do-colegio-inicial.json
@@ -2,20 +2,45 @@
   "id": "porto-real-do-colegio",
   "nome": "PORTO REAL DO COLÉGIO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 90,
-      "num_nomeacoes": 10,
+    "2015": {
+      "num_diarios": 45,
+      "num_nomeacoes": 8,
+      "num_exoneracoes": 5
+    },
+    "2016": {
+      "num_diarios": 31,
+      "num_nomeacoes": 5,
+      "num_exoneracoes": 1
+    },
+    "2017": {
+      "num_diarios": 47,
+      "num_nomeacoes": 33,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 69,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 72,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 90,
+      "num_nomeacoes": 10,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 36,
+      "num_nomeacoes": 30,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 162,
-    "num_exoneracoes": 0,
-    "num_nomeacoes": 10
+    "num_diarios": 390,
+    "num_exoneracoes": 6,
+    "num_nomeacoes": 86
   }
 }

--- a/docs/site/dados/inicial/quebrangulo-inicial.json
+++ b/docs/site/dados/inicial/quebrangulo-inicial.json
@@ -2,19 +2,34 @@
   "id": "quebrangulo",
   "nome": "QUEBRANGULO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 215,
-      "num_nomeacoes": 3,
+    "2017": {
+      "num_diarios": 1,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 100,
+      "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 177,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 215,
+      "num_nomeacoes": 3,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 62,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 392,
+    "num_diarios": 555,
     "num_exoneracoes": 0,
     "num_nomeacoes": 3
   }

--- a/docs/site/dados/inicial/rio-largo-inicial.json
+++ b/docs/site/dados/inicial/rio-largo-inicial.json
@@ -2,20 +2,30 @@
   "id": "rio-largo",
   "nome": "RIO LARGO",
   "detalhe": {
-    "2022": {
-      "num_diarios": 234,
-      "num_nomeacoes": 127,
-      "num_exoneracoes": 44
+    "2020": {
+      "num_diarios": 198,
+      "num_nomeacoes": 19,
+      "num_exoneracoes": 58
     },
     "2021": {
       "num_diarios": 226,
       "num_nomeacoes": 99,
       "num_exoneracoes": 21
+    },
+    "2022": {
+      "num_diarios": 234,
+      "num_nomeacoes": 127,
+      "num_exoneracoes": 44
+    },
+    "2023": {
+      "num_diarios": 67,
+      "num_nomeacoes": 73,
+      "num_exoneracoes": 8
     }
   },
   "resumo": {
-    "num_diarios": 460,
-    "num_exoneracoes": 65,
-    "num_nomeacoes": 226
+    "num_diarios": 725,
+    "num_exoneracoes": 131,
+    "num_nomeacoes": 318
   }
 }

--- a/docs/site/dados/inicial/roteiro-inicial.json
+++ b/docs/site/dados/inicial/roteiro-inicial.json
@@ -2,6 +2,11 @@
   "id": "roteiro",
   "nome": "ROTEIRO",
   "detalhe": {
+    "2020": {
+      "num_diarios": 90,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2021": {
       "num_diarios": 70,
       "num_nomeacoes": 0,
@@ -11,10 +16,15 @@
       "num_diarios": 87,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 23,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 157,
+    "num_diarios": 270,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/santa-luzia-do-norte-inicial.json
+++ b/docs/site/dados/inicial/santa-luzia-do-norte-inicial.json
@@ -2,20 +2,35 @@
   "id": "santa-luzia-do-norte",
   "nome": "SANTA LUZIA DO NORTE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 136,
-      "num_nomeacoes": 17,
+    "2017": {
+      "num_diarios": 53,
+      "num_nomeacoes": 114,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 93,
+      "num_nomeacoes": 5,
       "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 81,
       "num_nomeacoes": 55,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 136,
+      "num_nomeacoes": 17,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 30,
+      "num_nomeacoes": 4,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 217,
+    "num_diarios": 393,
     "num_exoneracoes": 0,
-    "num_nomeacoes": 72
+    "num_nomeacoes": 195
   }
 }

--- a/docs/site/dados/inicial/santana-do-ipanema-inicial.json
+++ b/docs/site/dados/inicial/santana-do-ipanema-inicial.json
@@ -2,20 +2,30 @@
   "id": "santana-do-ipanema",
   "nome": "SANTANA DO IPANEMA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 122,
+    "2020": {
+      "num_diarios": 109,
       "num_nomeacoes": 0,
-      "num_exoneracoes": 0
+      "num_exoneracoes": 16
     },
     "2021": {
       "num_diarios": 112,
       "num_nomeacoes": 12,
       "num_exoneracoes": 2
+    },
+    "2022": {
+      "num_diarios": 122,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 32,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 234,
-    "num_exoneracoes": 2,
+    "num_diarios": 375,
+    "num_exoneracoes": 18,
     "num_nomeacoes": 12
   }
 }

--- a/docs/site/dados/inicial/santana-do-mundau-inicial.json
+++ b/docs/site/dados/inicial/santana-do-mundau-inicial.json
@@ -2,8 +2,13 @@
   "id": "santana-do-mundau",
   "nome": "SANTANA DO MUNDAÚ",
   "detalhe": {
-    "2022": {
-      "num_diarios": 184,
+    "2017": {
+      "num_diarios": 6,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 118,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 164,
       "num_nomeacoes": 0,
       "num_exoneracoes": 1
+    },
+    "2022": {
+      "num_diarios": 184,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 53,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 348,
+    "num_diarios": 525,
     "num_exoneracoes": 1,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/sao-jose-da-laje-inicial.json
+++ b/docs/site/dados/inicial/sao-jose-da-laje-inicial.json
@@ -2,8 +2,8 @@
   "id": "sao-jose-da-laje",
   "nome": "SÃO JOSÉ DA LAJE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 120,
+    "2020": {
+      "num_diarios": 77,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 76,
       "num_nomeacoes": 4,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 120,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 41,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 196,
+    "num_diarios": 314,
     "num_exoneracoes": 0,
     "num_nomeacoes": 4
   }

--- a/docs/site/dados/inicial/sao-jose-da-tapera-inicial.json
+++ b/docs/site/dados/inicial/sao-jose-da-tapera-inicial.json
@@ -2,20 +2,35 @@
   "id": "sao-jose-da-tapera",
   "nome": "SÃO JOSÉ DA TAPERA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 215,
-      "num_nomeacoes": 96,
-      "num_exoneracoes": 21
+    "2017": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 91,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     },
     "2021": {
       "num_diarios": 141,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 215,
+      "num_nomeacoes": 96,
+      "num_exoneracoes": 21
+    },
+    "2023": {
+      "num_diarios": 60,
+      "num_nomeacoes": 114,
+      "num_exoneracoes": 7
     }
   },
   "resumo": {
-    "num_diarios": 356,
-    "num_exoneracoes": 21,
-    "num_nomeacoes": 96
+    "num_diarios": 538,
+    "num_exoneracoes": 28,
+    "num_nomeacoes": 210
   }
 }

--- a/docs/site/dados/inicial/sao-luis-do-quitunde-inicial.json
+++ b/docs/site/dados/inicial/sao-luis-do-quitunde-inicial.json
@@ -2,8 +2,13 @@
   "id": "sao-luis-do-quitunde",
   "nome": "SÃO LUIS DO QUITUNDE",
   "detalhe": {
-    "2022": {
-      "num_diarios": 127,
+    "2017": {
+      "num_diarios": 75,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 143,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 115,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 127,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 46,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 242,
+    "num_diarios": 506,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/sao-miguel-dos-milagres-inicial.json
+++ b/docs/site/dados/inicial/sao-miguel-dos-milagres-inicial.json
@@ -2,20 +2,25 @@
   "id": "sao-miguel-dos-milagres",
   "nome": "SÃO MIGUEL DOS MILAGRES",
   "detalhe": {
+    "2021": {
+      "num_diarios": 80,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
     "2022": {
       "num_diarios": 116,
       "num_nomeacoes": 5,
       "num_exoneracoes": 2
     },
-    "2021": {
-      "num_diarios": 80,
-      "num_nomeacoes": 0,
-      "num_exoneracoes": 0
+    "2023": {
+      "num_diarios": 45,
+      "num_nomeacoes": 6,
+      "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 196,
-    "num_exoneracoes": 2,
-    "num_nomeacoes": 5
+    "num_diarios": 241,
+    "num_exoneracoes": 3,
+    "num_nomeacoes": 11
   }
 }

--- a/docs/site/dados/inicial/sao-sebastiao-inicial.json
+++ b/docs/site/dados/inicial/sao-sebastiao-inicial.json
@@ -2,20 +2,30 @@
   "id": "sao-sebastiao",
   "nome": "SÃO SEBASTIÃO",
   "detalhe": {
-    "2022": {
+    "2020": {
       "num_diarios": 120,
       "num_nomeacoes": 0,
-      "num_exoneracoes": 0
+      "num_exoneracoes": 1
     },
     "2021": {
       "num_diarios": 102,
       "num_nomeacoes": 0,
       "num_exoneracoes": 1
+    },
+    "2022": {
+      "num_diarios": 120,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 35,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 222,
-    "num_exoneracoes": 1,
+    "num_diarios": 377,
+    "num_exoneracoes": 2,
     "num_nomeacoes": 0
   }
 }

--- a/docs/site/dados/inicial/satuba-inicial.json
+++ b/docs/site/dados/inicial/satuba-inicial.json
@@ -2,20 +2,30 @@
   "id": "satuba",
   "nome": "SATUBA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 120,
+    "2020": {
+      "num_diarios": 65,
       "num_nomeacoes": 0,
-      "num_exoneracoes": 1
+      "num_exoneracoes": 6
     },
     "2021": {
       "num_diarios": 130,
       "num_nomeacoes": 1,
       "num_exoneracoes": 10
+    },
+    "2022": {
+      "num_diarios": 120,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 32,
+      "num_nomeacoes": 52,
+      "num_exoneracoes": 1
     }
   },
   "resumo": {
-    "num_diarios": 250,
-    "num_exoneracoes": 11,
-    "num_nomeacoes": 1
+    "num_diarios": 347,
+    "num_exoneracoes": 18,
+    "num_nomeacoes": 53
   }
 }

--- a/docs/site/dados/inicial/senador-rui-palmeira-inicial.json
+++ b/docs/site/dados/inicial/senador-rui-palmeira-inicial.json
@@ -2,8 +2,13 @@
   "id": "senador-rui-palmeira",
   "nome": "SENADOR RUI PALMEIRA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 85,
+    "2017": {
+      "num_diarios": 28,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 63,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +16,20 @@
       "num_diarios": 57,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 85,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 32,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 142,
+    "num_diarios": 265,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/tanque-d arca-inicial.json
+++ b/docs/site/dados/inicial/tanque-d arca-inicial.json
@@ -2,8 +2,8 @@
   "id": "tanque-d arca",
   "nome": "TANQUE D´ARCA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 118,
+    "2020": {
+      "num_diarios": 28,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
     },
@@ -11,10 +11,20 @@
       "num_diarios": 84,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 118,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 24,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 202,
+    "num_diarios": 254,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/taquarana-inicial.json
+++ b/docs/site/dados/inicial/taquarana-inicial.json
@@ -2,20 +2,50 @@
   "id": "taquarana",
   "nome": "TAQUARANA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 153,
-      "num_nomeacoes": 4,
-      "num_exoneracoes": 2
+    "2014": {
+      "num_diarios": 7,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2015": {
+      "num_diarios": 32,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 21,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2017": {
+      "num_diarios": 14,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2020": {
+      "num_diarios": 52,
+      "num_nomeacoes": 202,
+      "num_exoneracoes": 18
     },
     "2021": {
       "num_diarios": 139,
       "num_nomeacoes": 25,
       "num_exoneracoes": 3
+    },
+    "2022": {
+      "num_diarios": 153,
+      "num_nomeacoes": 4,
+      "num_exoneracoes": 2
+    },
+    "2023": {
+      "num_diarios": 49,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 292,
-    "num_exoneracoes": 5,
-    "num_nomeacoes": 29
+    "num_diarios": 467,
+    "num_exoneracoes": 23,
+    "num_nomeacoes": 231
   }
 }

--- a/docs/site/dados/inicial/teotonio-vilela-inicial.json
+++ b/docs/site/dados/inicial/teotonio-vilela-inicial.json
@@ -2,20 +2,45 @@
   "id": "teotonio-vilela",
   "nome": "TEOTONIO VILELA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 219,
-      "num_nomeacoes": 100,
-      "num_exoneracoes": 3
+    "2015": {
+      "num_diarios": 31,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
+    },
+    "2016": {
+      "num_diarios": 79,
+      "num_nomeacoes": 34,
+      "num_exoneracoes": 35
+    },
+    "2017": {
+      "num_diarios": 136,
+      "num_nomeacoes": 20,
+      "num_exoneracoes": 1
+    },
+    "2020": {
+      "num_diarios": 199,
+      "num_nomeacoes": 165,
+      "num_exoneracoes": 46
     },
     "2021": {
       "num_diarios": 227,
       "num_nomeacoes": 267,
       "num_exoneracoes": 1
+    },
+    "2022": {
+      "num_diarios": 219,
+      "num_nomeacoes": 100,
+      "num_exoneracoes": 3
+    },
+    "2023": {
+      "num_diarios": 65,
+      "num_nomeacoes": 16,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 446,
-    "num_exoneracoes": 4,
-    "num_nomeacoes": 367
+    "num_diarios": 956,
+    "num_exoneracoes": 86,
+    "num_nomeacoes": 602
   }
 }

--- a/docs/site/dados/inicial/traipu-inicial.json
+++ b/docs/site/dados/inicial/traipu-inicial.json
@@ -11,10 +11,15 @@
       "num_diarios": 115,
       "num_nomeacoes": 0,
       "num_exoneracoes": 0
+    },
+    "2023": {
+      "num_diarios": 26,
+      "num_nomeacoes": 0,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 230,
+    "num_diarios": 256,
     "num_exoneracoes": 0,
     "num_nomeacoes": 0
   }

--- a/docs/site/dados/inicial/vicosa-inicial.json
+++ b/docs/site/dados/inicial/vicosa-inicial.json
@@ -2,20 +2,30 @@
   "id": "vicosa",
   "nome": "VIÇOSA",
   "detalhe": {
-    "2022": {
-      "num_diarios": 213,
-      "num_nomeacoes": 12,
-      "num_exoneracoes": 1
+    "2020": {
+      "num_diarios": 119,
+      "num_nomeacoes": 74,
+      "num_exoneracoes": 8
     },
     "2021": {
       "num_diarios": 175,
       "num_nomeacoes": 10,
       "num_exoneracoes": 0
+    },
+    "2022": {
+      "num_diarios": 213,
+      "num_nomeacoes": 12,
+      "num_exoneracoes": 1
+    },
+    "2023": {
+      "num_diarios": 61,
+      "num_nomeacoes": 22,
+      "num_exoneracoes": 0
     }
   },
   "resumo": {
-    "num_diarios": 388,
-    "num_exoneracoes": 1,
-    "num_nomeacoes": 22
+    "num_diarios": 568,
+    "num_exoneracoes": 9,
+    "num_nomeacoes": 118
   }
 }

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -142,5 +142,80 @@
             <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
         </div>
     </div>
+    <h1>2020</h1><br>
+    <div class="card" id="ano-2020">
+        <div>
+            <h2>Diários</h2>
+            <p>Número de diários: <div id="num-diarios"></div></p>
+        </div>
+        <div>
+            <h2>Nomeações</h2>
+            <p>Número de nomeações: <div id="num-nomeacoes"></div></p>
+        </div>
+        <div>
+            <h2>Exonerações</h2>
+            <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
+        </div>
+    </div>
+    <h1>2017</h1><br>
+    <div class="card" id="ano-2017">
+        <div>
+            <h2>Diários</h2>
+            <p>Número de diários: <div id="num-diarios"></div></p>
+        </div>
+        <div>
+            <h2>Nomeações</h2>
+            <p>Número de nomeações: <div id="num-nomeacoes"></div></p>
+        </div>
+        <div>
+            <h2>Exonerações</h2>
+            <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
+        </div>
+    </div>
+    <h1>2016</h1><br>
+    <div class="card" id="ano-2016">
+        <div>
+            <h2>Diários</h2>
+            <p>Número de diários: <div id="num-diarios"></div></p>
+        </div>
+        <div>
+            <h2>Nomeações</h2>
+            <p>Número de nomeações: <div id="num-nomeacoes"></div></p>
+        </div>
+        <div>
+            <h2>Exonerações</h2>
+            <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
+        </div>
+    </div>
+    <h1>2015</h1><br>
+    <div class="card" id="ano-2015">
+        <div>
+            <h2>Diários</h2>
+            <p>Número de diários: <div id="num-diarios"></div></p>
+        </div>
+        <div>
+            <h2>Nomeações</h2>
+            <p>Número de nomeações: <div id="num-nomeacoes"></div></p>
+        </div>
+        <div>
+            <h2>Exonerações</h2>
+            <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
+        </div>
+    </div>
+    <h1>2014</h1><br>
+    <div class="card" id="ano-2014">
+        <div>
+            <h2>Diários</h2>
+            <p>Número de diários: <div id="num-diarios"></div></p>
+        </div>
+        <div>
+            <h2>Nomeações</h2>
+            <p>Número de nomeações: <div id="num-nomeacoes"></div></p>
+        </div>
+        <div>
+            <h2>Exonerações</h2>
+            <p>Número de exoneraçoes: <div id="num-exoneracoes"></div></p>
+        </div>
+    </div>
 </body>
 </html>

--- a/docs/site/index.js
+++ b/docs/site/index.js
@@ -1,28 +1,29 @@
-const selectElement = document.querySelector('#municipio-select');
+const selectElement = document.querySelector("#municipio-select");
 
-selectElement.addEventListener('change', updateData);
+selectElement.addEventListener("change", updateData);
 
 function updateData() {
-    var municipio = selectElement.value;
-    console.log(municipio)
+  var municipio = selectElement.value;
+  console.log(municipio);
 
-    const cards = document.querySelectorAll('.card');
-    cards.forEach(card => {
-        const ano = card.id.replace('ano-', '');
-        fetch(`./dados/inicial/${municipio}-inicial.json`)
-            .then(response => response.json())
-            .then(data => {
-                const detalhe_ano = data.detalhe[ano]
-
-                const numDiarios = document.querySelector(`#ano-${ano} #num-diarios`);
-                numDiarios.textContent = detalhe_ano.num_diarios;
-
-                const numExoneracoes = document.querySelector(`#ano-${ano} #num-exoneracoes`);
-                numExoneracoes.textContent = detalhe_ano.num_exoneracoes;
-
-                const numNomeacoes = document.querySelector(`#ano-${ano} #num-nomeacoes`);
-                numNomeacoes.textContent = detalhe_ano.num_nomeacoes;
-            });
-    });
+  const cards = document.querySelectorAll(".card");
+  cards.forEach((card) => {
+    const ano = card.id.replace("ano-", "");
+    fetch(`./dados/inicial/${municipio}-inicial.json`)
+      .then((response) => response.json())
+      .then((data) => {
+        const detalhe_ano = data.detalhe[ano];
+        const numDiarios = document.querySelector(`#ano-${ano} #num-diarios`);
+        numDiarios.textContent = detalhe_ano ? detalhe_ano.num_diarios: "0";
+        const numExoneracoes = document.querySelector(
+          `#ano-${ano} #num-exoneracoes`
+        );
+        numExoneracoes.textContent = detalhe_ano ? detalhe_ano.num_exoneracoes : "0";
+        const numNomeacoes = document.querySelector(
+          `#ano-${ano} #num-nomeacoes`
+        );
+        numNomeacoes.textContent = detalhe_ano ? detalhe_ano.num_nomeacoes : "0";
+      });
+  });
 }
-updateData()
+updateData();

--- a/docs/site/site_home_data.py
+++ b/docs/site/site_home_data.py
@@ -4,12 +4,13 @@ import os
 
 os.makedirs("./docs/site/dados/inicial", exist_ok=True)
 
-inicial = {}  # Dicionário que guarda dados para renderização da página inicial.
+# Dicionário que guarda dados para renderização da página inicial.
+inicial = {}
 geral = {
     "detalhe": {},
-}  
+}
 for path in glob.glob("./data/diarios/*-atos.json"):
-    with open(path) as json_file:
+    with open(path, encoding="utf-8") as json_file:
         diarios = json.load(json_file)
 
         for diario in diarios:
@@ -26,11 +27,13 @@ for path in glob.glob("./data/diarios/*-atos.json"):
             dado_municipio = inicial.get(id_municipio, {})
             detalhe = dado_municipio.get("detalhe", {})
             detalhe_ano = detalhe.get(ano, {})
-            detalhe_ano["num_diarios"] = detalhe_ano.get("num_diarios", 0) + 1 
+            detalhe_ano["num_diarios"] = detalhe_ano.get("num_diarios", 0) + 1
             for ato in diario["atos"]:
                 ato = json.loads(ato)
-                detalhe_ano["num_nomeacoes"] = detalhe_ano.get("num_nomeacoes", 0) + len(ato["cpf_nomeacoes"])
-                detalhe_ano["num_exoneracoes"] = detalhe_ano.get("num_exoneracoes", 0) + len(ato["cpf_exoneracoes"])
+                detalhe_ano["num_nomeacoes"] = detalhe_ano.get(
+                    "num_nomeacoes", 0) + len(ato["cpf_nomeacoes"])
+                detalhe_ano["num_exoneracoes"] = detalhe_ano.get(
+                    "num_exoneracoes", 0) + len(ato["cpf_exoneracoes"])
             detalhe[ano] = detalhe_ano
 
             inicial[id_municipio] = {
@@ -42,9 +45,12 @@ for path in glob.glob("./data/diarios/*-atos.json"):
             # Atualizando seção de detalhes geral.
             detalhe_geral = geral.get("detalhe", {})
             detalhe_geral_ano = detalhe_geral.get(ano, {})
-            detalhe_geral_ano["num_diarios"] = detalhe_geral_ano.get("num_diarios", 0) + 1
-            detalhe_geral_ano["num_nomeacoes"] = detalhe_geral_ano.get("num_nomeacoes", 0) + detalhe_ano.get("num_nomeacoes", 0)
-            detalhe_geral_ano["num_exoneracoes"] = detalhe_geral_ano.get("num_exoneracoes", 0) + detalhe_ano.get("num_exoneracoes", 0)
+            detalhe_geral_ano["num_diarios"] = detalhe_geral_ano.get(
+                "num_diarios", 0) + 1
+            detalhe_geral_ano["num_nomeacoes"] = detalhe_geral_ano.get(
+                "num_nomeacoes", 0) + detalhe_ano.get("num_nomeacoes", 0)
+            detalhe_geral_ano["num_exoneracoes"] = detalhe_geral_ano.get(
+                "num_exoneracoes", 0) + detalhe_ano.get("num_exoneracoes", 0)
             detalhe_geral[ano] = detalhe_geral_ano
 
             inicial["geral"] = {
@@ -66,7 +72,7 @@ for id_municipio, dado in inicial.items():
     inicial[id_municipio]["resumo"] = {
         "num_diarios": num_diarios,
         "num_exoneracoes": num_exoneracoes,
-        "num_nomeacoes": num_nomeacoes,    
+        "num_nomeacoes": num_nomeacoes,
     }
 
 # Salvando dados para renderização da página inicial.


### PR DESCRIPTION
- Esta PR atualizou os arquivos JSON de todos os municípios para incluir mais anos (**os únicos anos não gerados para os arquivos JSON foram 2018 e 2019**, devido ao erro mencionado no grupo PIBIC - IFAL QD).
- Esta PR corrigiu um erro de visualização de dados no site em que, quando um município não tinha dados para determinado ano, os dados carregados eram pertencentes ao último município que fora selecionado e que possuía dados para aquele ano, ao invés de ficar “0” **(mudanças no arquivo index.js)**.
- Formatação do código dos arquivos `site_home_data.py` e `index.js.`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/danielfireman/ifal-qd/142)
<!-- Reviewable:end -->
